### PR TITLE
Fix session duration bugs causing early credential expiry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SAML to AWS STS Keys Conversion
-Google Chrome Extension, which converts a SAML 2.0 assertion to AWS STS Keys (temporary credentials). Just log in to the AWS Web Management Console using your SAML IDP and the Chrome Extension will fetch the SAML Assertion from the HTTP request. The SAML Assertion is then used to call the assumeRoleWithSAML API to create the temporary credentials. (AccessKeyId, SecretAccessKey and SessionToken).
+Browser Extension, which converts a SAML 2.0 assertion to AWS STS Keys (temporary credentials). Just log in to the AWS Web Management Console using your SAML IDP and the extension will fetch the SAML Assertion from the HTTP request. The SAML Assertion is then used to call the assumeRoleWithSAML API to create the temporary credentials. (AccessKeyId, SecretAccessKey and SessionToken).
+
+> **Note:** This extension currently uses Manifest V2 and is not supported in Chrome 127+. Use a Chromium-based browser that still supports MV2 (e.g., Brave, Edge) or Mozilla Firefox. Alternatively, in Chrome you can re-enable MV2 support via `chrome://flags` by setting "Extensions Manifest V2 Deprecation" to Enabled.
 
 The Chrome Extension can be downloaded here:
 [Google Chrome Web Store](https://chrome.google.com/webstore/detail/ekniobabpcnfjgfbphhcolcinmnbehde/)
@@ -22,7 +24,7 @@ The Security Token Service (STS) from AWS provides an API action assumeRoleWithS
 
 ## <a name="gettingstarted"></a>Getting Started from local
 1. Clone this repository
-2. Open Chrome and go to `chrome://extensions/`
+2. Open a Chromium-based browser that supports Manifest V2 (e.g., Brave, Edge) and go to the extensions page (e.g., `brave://extensions/` or `edge://extensions/`)
 3. Enable Developer Mode
 4. Click on "Load unpacked extension..."
 5. Select the folder where you cloned this repository
@@ -36,7 +38,7 @@ ln -s ~/Downloads/credentials ~/.aws/credentials
 
 ## <a name="faq"></a>FAQ: Frequently Asked Question
 1. How long are the credentials valid?  
-By default, the credentials are valid for 4 hours. This can be changed in the AWS IAM console or Extension settings.
+By default, the credentials are valid for 12 hours. This can be changed in the AWS IAM console or Extension settings. Note: the requested duration cannot exceed the MaxSessionDuration set on the IAM role.
 
 ## <a name="todo"></a>TODO
 1. Migrate from [Manifest v2 to v3](https://blog.chromium.org/2020/12/manifest-v3-now-available-on-m88-beta.html)

--- a/background/script.js
+++ b/background/script.js
@@ -1,7 +1,7 @@
 // Global variables
 var FileName = 'credentials';
 var ApplySessionDuration = false;
-var SessionDuration = 14400;
+var SessionDuration = 43200;
 var DebugLogs = true;
 var RoleArns = {};
 var LF = '\n';
@@ -248,7 +248,7 @@ function assumeAdditionalRole(profileList, index, AccessKeyId, SecretAccessKey, 
 		// Otherwise, this is the last profile/role in the RoleArns dict. Proceed to creating the credentials file
 		if (index < profileList.length - 1) {
 			console.log('INFO: Do additional assume-role for role -> ' + RoleArns[profileList[index + 1]]);
-			assumeAdditionalRole(profileList, index + 1, AccessKeyId, SecretAccessKey, SessionToken, docContent);
+			assumeAdditionalRole(profileList, index + 1, AccessKeyId, SecretAccessKey, SessionToken, docContent, SessionDuration);
 		} else {
 			outputDocAsDownload(docContent);
 		}
@@ -305,12 +305,12 @@ function loadItemsFromStorage() {
   chrome.storage.sync.get({
     FileName: 'credentials',
     ApplySessionDuration: 'no',
-    SessionDuration: '14400',
+    SessionDuration: '43200',
     DebugLogs: 'yes',
     RoleArns: {}
   }, function(items) {
     FileName = items.FileName;
-    SessionDuration = items.SessionDuration;
+    SessionDuration = Number(items.SessionDuration);
     if (items.ApplySessionDuration == "no") {
       ApplySessionDuration = false;
     } else {

--- a/options/options.html
+++ b/options/options.html
@@ -41,7 +41,7 @@
 			</select>
 		</div>
 		<div id="divFilename" class="setting-part">
-			<label>Set Session Duration in seconds. Example: 14400 is 4 hours<br>Note: the requested DurationSeconds can NOT be more than MaxSessionDuration set for this role</label>
+			<label>Set Session Duration in seconds. Example: 43200 is 12 hours<br>Note: the requested DurationSeconds can NOT be more than MaxSessionDuration set for this role</label>
 			<br />
 			<input type="text" name="SessionDurationSeconds" id="SessionDurationSeconds" size="40">
 		</div>

--- a/options/options.js
+++ b/options/options.js
@@ -53,7 +53,7 @@ function restore_options() {
 		// Default values
 		FileName: 'credentials',
 		ApplySessionDuration: 'no',
-		SessionDuration: '14400',
+		SessionDuration: '43200',
 		DebugLogs: 'no',
 		RoleArns: {}
 	}, function (items) {


### PR DESCRIPTION
## Summary
- **Bug fix:** `SessionDuration` was loaded from Chrome storage as a string instead of a number, causing the AWS STS API to ignore it and fall back to the default 1-hour expiry. Fixed by converting with `Number()`.
- **Bug fix:** Recursive `assumeAdditionalRole()` call was missing the `SessionDuration` argument, so 2nd+ additional roles also fell back to 1-hour duration.
- **Default changed:** Session duration increased from 4 hours (14400s) to 12 hours (43200s).

## Test plan
- [ ] Load the extension and verify DEBUG logs show `SessionDuration: 43200` (number, not string)
- [ ] Confirm credentials file has tokens that last 12 hours
- [ ] If using additional roles, verify all role profiles get the correct duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)